### PR TITLE
INTG-2037 remove default picklist value

### DIFF
--- a/fixtures/_generated/connector.rb
+++ b/fixtures/_generated/connector.rb
@@ -270,7 +270,6 @@
             hint: "Trigger event to subscribe to.",
             
             control_type: "select",
-            default: "TRIGGER_EVENT_INSPECTION_STARTED",
             pick_list: "enum_api_tasks_v1_triggerinspectionrequest_triggerevent",
             sticky: true,
             

--- a/template/object_definition.go
+++ b/template/object_definition.go
@@ -121,10 +121,6 @@ func (t *WorkatoTemplate) getFieldDef(field *gendoc.MessageField) *FieldDefiniti
 		fieldDef.Picklist = enumPicklistName(enum)
 		if field.Label == "repeated" {
 			fieldDef.ControlType = "multiselect"
-		} else {
-			if fieldDef.Default == "" {
-				fieldDef.Default = enum.Values[0].Name
-			}
 		}
 	} else {
 		if field.Label == "repeated" {


### PR DESCRIPTION
Having a default auto populated creates some trouble in workato rendering (especially where we have combo objects with one dropdown and one optional value).
