### PR TITLE
Rename output file to connector.rb

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -53,7 +53,7 @@ func (p *Plugin) Generate(r *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGener
 	}
 
 	resp.File = append(resp.File, &pluginpb.CodeGeneratorResponse_File{
-		Name:    proto.String("workato_connector.rb"),
+		Name:    proto.String("connector.rb"),
 		Content: proto.String(string(workatoOutput)),
 	})
 


### PR DESCRIPTION
This is what the Workato SDK expects by default. Just makes things a bit easier to manage.