### PR TITLE
[INTG-2163] Fix workato not accepting data pills on Use ID

### DIFF
--- a/.snapshots/TestGenerateWorkatoConnector
+++ b/.snapshots/TestGenerateWorkatoConnector
@@ -371,6 +371,7 @@
               type: "string",
               hint: "<p>The ID of the task</p>",
               
+              control_type: "text",
               toggle_hint: "Use ID",
               
               sticky: true,
@@ -521,6 +522,7 @@
               label: "Timezone",
               type: "string",
               
+              control_type: "text",
               toggle_hint: "Use ID",
               
               sticky: true,

--- a/template/object.go
+++ b/template/object.go
@@ -130,7 +130,7 @@ func (t *WorkatoTemplate) getFieldDef(field *gendoc.MessageField) *schema.FieldD
 			}
 
 			toggleFieldDef := *fieldDef
-			toggleFieldDef.ControlType = ""
+			toggleFieldDef.ControlType = "text"
 			toggleFieldDef.Picklist = ""
 			toggleFieldDef.ToggleHint = "Use ID"
 


### PR DESCRIPTION
"text" is required at the control type in order to correctly support data pulls in this field type.